### PR TITLE
Add greeting and registration date to user model

### DIFF
--- a/src/main/java/modelo/DescuentoPorFecha.java
+++ b/src/main/java/modelo/DescuentoPorFecha.java
@@ -17,7 +17,7 @@ public class DescuentoPorFecha implements Descuento {
  @Override
  public double calcularDescuento(Usuario u) {
      LocalDate hoy = LocalDate.now();
-     LocalDate alta = u.getFechaNacimiento(); // o fecha de registro si la guardas ahí
+     LocalDate alta = u.getFechaRegistro();
      long años = ChronoUnit.YEARS.between(alta, hoy);
      return (años >= añosMinimos) ? factor : 0.0;
  }

--- a/src/main/java/modelo/Usuario.java
+++ b/src/main/java/modelo/Usuario.java
@@ -15,7 +15,9 @@ public class Usuario {
     private final String telefono;
     private final String contrasenia;
     private final LocalDate fechaNacimiento;  // opcional
-    private final String imagenPerfil;        // opcional (ruta o URL)
+    private final LocalDate fechaRegistro;    // alta en el sistema
+    private final String  saludo;             // opcional
+    private final String  imagenPerfil;       // opcional (ruta o URL)
     private final boolean isPremium;
 
     // — Campos mutables (listas) —
@@ -29,6 +31,8 @@ public class Usuario {
         this.telefono        = b.telefono;
         this.contrasenia     = b.contrasenia;
         this.fechaNacimiento = b.fechaNacimiento;
+        this.fechaRegistro   = b.fechaRegistro != null ? b.fechaRegistro : LocalDate.now();
+        this.saludo          = b.saludo;
         this.imagenPerfil    = b.imagenPerfil;
         this.isPremium       = b.isPremium;
     }
@@ -40,6 +44,8 @@ public class Usuario {
     public String getTelefono()         { return telefono; }
     public String getContrasenia()      { return contrasenia; }
     public LocalDate getFechaNacimiento(){ return fechaNacimiento; }
+    public LocalDate getFechaRegistro() { return fechaRegistro; }
+    public String getSaludo()           { return saludo; }
     public String getImagenPerfil()     { return imagenPerfil; }
     public boolean isPremium()          { return isPremium; }
 
@@ -75,6 +81,8 @@ public class Usuario {
 
         // opcionales con valores por defecto
         private LocalDate fechaNacimiento = null;
+        private LocalDate fechaRegistro  = null;
+        private String   saludo          = "";
         private String   imagenPerfil    = null;
         private boolean  isPremium       = false;
 
@@ -87,6 +95,16 @@ public class Usuario {
 
         public Builder fechaNacimiento(LocalDate fecha) {
             this.fechaNacimiento = fecha;
+            return this;
+        }
+
+        public Builder fechaRegistro(LocalDate fecha) {
+            this.fechaRegistro = fecha;
+            return this;
+        }
+
+        public Builder saludo(String saludo) {
+            this.saludo = saludo;
             return this;
         }
 

--- a/src/main/java/test/ModeloTest.java
+++ b/src/main/java/test/ModeloTest.java
@@ -15,10 +15,13 @@ public class ModeloTest {
     public static void main(String[] args) {
         // 1) Creo un usuario de ejemplo
         Usuario u = new Usuario.Builder("Prueba", "prueba@ej.com", "600000000", "1234")
-                        .fechaNacimiento(LocalDate.now().minusYears(2))
+                        .fechaNacimiento(LocalDate.of(1990,1,1))
+                        .fechaRegistro(LocalDate.now().minusYears(6))
+                        .saludo("Hola, soy demo")
                         .premium(true)
                         .build();
         System.out.println("Usuario creado: " + u.getNombre() + ", tel=" + u.getTelefono());
+        System.out.println("Saludo: " + u.getSaludo() + ", registrado el " + u.getFechaRegistro());
 
         // 2) Creo un contacto individual y un grupo
         ContactoIndividual ci = FactoriaContacto.crearIndividual("Amigo", "611111111");


### PR DESCRIPTION
## Summary
- add `fechaRegistro` and `saludo` fields to `Usuario`
- update builder with new options
- expose new getters
- compute date-based discount using registration date
- expand model test to show new fields

## Testing
- `javac -d out @compile_sources3.txt`
- `java -cp out test.ModeloTest`

------
https://chatgpt.com/codex/tasks/task_e_6846a7597668832783c5880755d6d7fb